### PR TITLE
fix: display sites alphabetically in manage-sites tool

### DIFF
--- a/src/scripts/manage-sites.ts
+++ b/src/scripts/manage-sites.ts
@@ -28,9 +28,14 @@ async function selectDomain(): Promise<string | null> {
       return null;
     }
     
+    // Sort sites alphabetically by domain
+    const sortedSites = sites.sort((a: any, b: any) => {
+      return a._id.localeCompare(b._id);
+    });
+    
     // Show sites with numbers
     console.log('\nAvailable sites:');
-    sites.forEach((site: any, index: number) => {
+    sortedSites.forEach((site: any, index: number) => {
       const domain = site._id;
       const startPageCount = site.scrapeConfig?.startPages?.length || 0;
       console.log(`${index + 1}. ${domain} (${startPageCount} start pages)`);
@@ -47,7 +52,7 @@ async function selectDomain(): Promise<string | null> {
       return null;
     }
     
-    return sites[index]._id;
+    return sortedSites[index]._id;
   } catch (error) {
     log.error('Failed to get sites', { error });
     return null;


### PR DESCRIPTION
## Summary
- Sites are now displayed in alphabetical order in the interactive site management tool
- Makes it easier to find specific sites in the list

## Changes
- Added sorting by domain name using `localeCompare()` before displaying sites
- Updated index reference to use the sorted array

🤖 Generated with [Claude Code](https://claude.ai/code)