### PR TITLE
Add option to list sites with outstanding scrape runs

### DIFF
--- a/src/drivers/scrape-runs.ts
+++ b/src/drivers/scrape-runs.ts
@@ -23,6 +23,14 @@ const log = logger.createContext('scrape-runs-driver');
  * Wraps ETL API provider functions with additional logic and error handling
  */
 
+/**
+ * List scrape runs with optional filters
+ * 
+ * @param options.since - Filter runs created after this date (driver abstracts to API's startTimeAfter)
+ * @param options.domain - Filter by domain
+ * @param options.status - Filter by status
+ * @param options.limit - Max results to return
+ */
 export async function listRuns(options: ListScrapeRunsOptions = {}): Promise<{ runs: ScrapeRun[] }> {
   try {
     log.debug('Listing scrape runs', options);

--- a/src/providers/etl-api.ts
+++ b/src/providers/etl-api.ts
@@ -242,7 +242,8 @@ export async function listScrapeRuns(query?: ListScrapeRunsQuery): Promise<ListS
   const params = new URLSearchParams();
   if (query?.domain) params.append('domain', query.domain);
   if (query?.status) params.append('status', query.status);
-  if (query?.since) params.append('since', query.since.toISOString());
+  // API expects 'startTimeAfter' not 'since'
+  if (query?.since) params.append('startTimeAfter', query.since.toISOString());
   if (query?.until) params.append('until', query.until.toISOString());
   if (query?.limit) params.append('limit', query.limit.toString());
   if (query?.offset) params.append('offset', query.offset.toString());

--- a/src/scripts/manage-sites.ts
+++ b/src/scripts/manage-sites.ts
@@ -163,16 +163,7 @@ async function listSitesWithOutstandingRuns(since?: Date) {
     
     const pendingRuns = pendingRunsResponse.runs || [];
     const processingRuns = processingRunsResponse.runs || [];
-    let allOutstandingRuns = [...pendingRuns, ...processingRuns];
-    
-    // Filter by date if since is provided (in case API doesn't filter)
-    if (since) {
-      const sinceTime = since.getTime();
-      allOutstandingRuns = allOutstandingRuns.filter(run => {
-        const runDate = new Date(run.created_at || run.createdAt || '');
-        return runDate.getTime() >= sinceTime;
-      });
-    }
+    const allOutstandingRuns = [...pendingRuns, ...processingRuns];
     
     if (allOutstandingRuns.length === 0) {
       console.log('\nNo sites have outstanding scrape runs.');


### PR DESCRIPTION
## Summary
- Added new menu option (6) to the manage-sites tool to show sites with outstanding (pending/processing) scrape runs
- Shows actual run statistics from the most recent outstanding run per site
- Added interactive time period filter when selecting the menu option
- Added --since parameter support to filter runs by date

## Changes
### Interactive Time Period Filter
- When selecting option 6, users are now prompted: "Filter by time period (e.g., 1d, 24h, 7d, 1w, or press Enter for all):"
- Supported formats:
  - `1d` - Last 1 day
  - `24h` - Last 24 hours  
  - `7d` - Last 7 days
  - `1w` - Last 1 week
  - `48h` - Last 48 hours
  - `30m` - Last 30 minutes
- Press Enter to show all outstanding runs (no filter)
- The prompt only appears if `--since` was not already provided via CLI

### Outstanding Runs Display
- `listSitesWithOutstandingRuns()` function:
  - Fetches all pending and processing runs from the API
  - Finds the most recent outstanding run for each domain
  - Displays run statistics in a formatted table with columns: Domain, Status, Total Items, Processed, Failed, Invalid, Remaining, Created
  - Sorts by remaining items (descending) to prioritize sites with most work left
  - Shows comprehensive summary statistics at the bottom

### Command Line Options
- Added `--since <date>` parameter to filter runs created after a specific date
- Added `--help` option to show usage instructions  
- Date format support: YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss

### Other Changes
- Fixed type imports in `scrape-runs.ts` driver:
  - Import types directly from `types/scrape-run.js` instead of from provider
  - Fixed `finalizeRun` return type to match provider (void instead of ScrapeRun)
- Changed date display from ISO format to locale format for better readability

## Example usage
```bash
# Show all outstanding runs with interactive prompt
npm run sites:manage
# Select option 6
# Enter "1d" to see runs from last 24 hours

# Show outstanding runs created after a specific date (bypasses prompt)
npm run sites:manage --since 2024-01-15
npm run sites:manage --since 2024-01-15T10:30:00
```

## Test plan
- [ ] Run `npm run sites:manage --help` and verify usage instructions show time period formats
- [ ] Run `npm run sites:manage` and select option 6
- [ ] Try various time periods: 1d, 24h, 7d, 1w, 30m
- [ ] Press Enter to show all runs (no filter)
- [ ] Verify table displays correctly with run statistics
- [ ] Test with `--since` parameter (should bypass the prompt)
- [ ] Verify sites are sorted by remaining items count
- [ ] Verify summary statistics are calculated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)