### PR TITLE
Fix scrape command to respect local browser flags

### DIFF
--- a/scripts/scrape.ts
+++ b/scripts/scrape.ts
@@ -61,8 +61,13 @@ interface ItemsOptions {
 
 async function runPaginate(options: PaginateOptions) {
   const siteManager = new SiteManager();
+  
+  // Determine provider based on browser flags
+  const provider = (options.localHeaded || options.localHeadless) ? 'local' : 'browserbase';
+  
   const sessionManager = new SessionManager({
-    sessionLimit: options.instanceLimit || 10
+    sessionLimit: options.instanceLimit || 10,
+    provider
   });
   
   await siteManager.loadSites();
@@ -105,8 +110,13 @@ async function runPaginate(options: PaginateOptions) {
 
 async function runItems(options: ItemsOptions) {
   const siteManager = new SiteManager();
+  
+  // Determine provider based on browser flags
+  const provider = (options.localHeaded || options.localHeadless) ? 'local' : 'browserbase';
+  
   const sessionManager = new SessionManager({
-    sessionLimit: options.instanceLimit || 10
+    sessionLimit: options.instanceLimit || 10,
+    provider
   });
   
   await siteManager.loadSites();


### PR DESCRIPTION
## Summary
- Fixed SessionManager creation in scrape.ts to use 'local' provider when --local-headed or --local-headless flags are used
- Previously these flags were passed to the engine but ignored during SessionManager creation, causing it to always use browserbase

## Test plan
- [x] Tested `npm run scrape paginate -- --sites=kulakovsky.online --force --local-headed`
- [x] Verified that local browser sessions are created instead of browserbase sessions
- [x] Confirmed browser type shows "Browser: local (headed)" in logs

🤖 Generated with [Claude Code](https://claude.ai/code)