### PR TITLE
Add parallel processing to scrape:items:json

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,15 @@ npm run scrape:items:json -- --dir=/path/to/json/files --no-s3
 
 # Start processing from a specific line (0-indexed, useful for resuming large files)
 npm run scrape:items:json -- --dir=/path/to/json/files --start-line=1000
+
+# Control parallel processing (limit concurrent items, useful for rate limiting)
+npm run scrape:items:json -- --dir=/path/to/json/files --parallel-limit=10
 ```
 
-Note: JSON/JSONL files must be named with the domain they contain (e.g., `shop.diesel.com.jsonl`).
+Note: 
+- JSON/JSONL files must be named with the domain they contain (e.g., `shop.diesel.com.jsonl`)
+- Items are processed in batches (default: 100). Within each batch, items are processed in parallel for better performance
+- Use `--parallel-limit` to control concurrency if you experience rate limiting or memory issues
 
 ### Verification Commands
 


### PR DESCRIPTION
Significantly improves performance by processing items within each batch in parallel.

## Key changes:
- Items within each batch are processed concurrently using Promise.all
- Added --parallel-limit parameter to control max concurrent operations  
- Both JSONL and regular JSON files now use parallel processing
- Maintains batch-based saving to ETL for efficiency

## Performance improvement:
- Instead of processing items one-by-one, processes entire batches in parallel
- Configurable parallelism with --parallel-limit to prevent overwhelming resources
- S3 uploads already used parallel processing, now item scraping does too

## Usage:
```bash
# Process with unlimited parallelism within each batch (default)
npm run scrape:items:json -- --dir=/path/to/files

# Limit to 10 concurrent operations
npm run scrape:items:json -- --dir=/path/to/files --parallel-limit=10
```